### PR TITLE
Relaxing check on ConnectSpeaker request-action

### DIFF
--- a/openlink-core/src/main/java/com/bt/openlink/type/RequestAction.java
+++ b/openlink-core/src/main/java/com/bt/openlink/type/RequestAction.java
@@ -25,7 +25,7 @@ public enum RequestAction {
     PUBLIC_CALL("PublicCall", "Make a call public", 0),
     ADD_THIRD_PARTY("AddThirdParty", "Add a third party to a call, making it a conference if necessary", 1),
     REMOVE_THIRD_PARTY("RemoveThirdParty", "Remove a third party from a call", 1),
-    CONNECT_SPEAKER("ConnectSpeaker", "Put a call on a speaker channel", 1),
+    CONNECT_SPEAKER("ConnectSpeaker", "Put a call on a speaker channel", 0),
     DISCONNECT_SPEAKER("DisconnectSpeaker", "Remove a call from a speaker channel", 1);
 
     @Nonnull private final String id;


### PR DESCRIPTION
The Openlink spec (SEE 4.8.1) specifies that a ConnectSpeaker request-action requires value1 to be set.
The ITS implementation however allows zero valueX parameters to be supplied, in which case the 'next free speaker' will be allocated